### PR TITLE
Update approach used to obtain principal ID in the API project

### DIFF
--- a/3-Authorization-II/2-call-api-b2c/API/TodoListAPI/Controllers/TodoListController.cs
+++ b/3-Authorization-II/2-call-api-b2c/API/TodoListAPI/Controllers/TodoListController.cs
@@ -37,7 +37,7 @@ namespace TodoListAPI.Controllers
 
             if (!IsAppOnlyToken() && _currentPrincipal != null)
             {
-                _currentPrincipalId = _currentPrincipal.GetHomeObjectId(); // use "sub" claim as a unique identifier in B2C
+                _currentPrincipalId = _currentPrincipal.GetNameIdentifierId(); // use "sub" claim as a unique identifier in B2C
                 PopulateDefaultToDos(_currentPrincipalId);
             }
         }

--- a/3-Authorization-II/2-call-api-b2c/API/TodoListAPI/Controllers/TodoListController.cs
+++ b/3-Authorization-II/2-call-api-b2c/API/TodoListAPI/Controllers/TodoListController.cs
@@ -37,6 +37,11 @@ namespace TodoListAPI.Controllers
 
             if (!IsAppOnlyToken() && _currentPrincipal != null)
             {
+                // The default behavior of the JwtSecurityTokenHandler is to map inbound claim names to new values in the generated ClaimsPrincipal. 
+                // The result is that "sub" claim that identifies the subject of the incoming JWT token is mapped to a claim
+                // named "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier". An alternative approach is to 
+                // disable this mapping by setting JwtSecurityTokenHandler.DefaultMapInboundClaims to false in Startup.cs and
+                // then calling _currentPrincipal.FindFirstValue(ClaimConstants.Sub) to obtain the value of the unmapped "sub" claim.
                 _currentPrincipalId = _currentPrincipal.GetNameIdentifierId(); // use "sub" claim as a unique identifier in B2C
                 PopulateDefaultToDos(_currentPrincipalId);
             }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

In the current incarnations of ASP.NET Core, B2C, etc, the user ID is being returned by default by the SUSI policy as the sub claim. ASP.NET Core is mapping this to the Name Identifier ID claim on the Claims Principal. As a result, the Home Object ID claim that the original code was looking for ("oid") is not present. The application seems to work, in that items are added/removed to/from the list, but in fact it is treating content with a "null" _currentPrincipalId. This can be seen by logging in as 1 user, creating a TODO item, then logging out and logging back in as another user - you will see the TODO item created by the first user in the second user's list.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No (it is intended to fix broken functionality.)
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->

See description, above for scenario and how to check for fix. 

## What to Check
Verify that the following are valid
* User ID is obtained from the incoming B2C user's claims
* List items are indexed by User ID and kept separate between users.

## Other Information
Alternatively, can consider the following code, in case this behavior has diverged in B2C and both principal ID claim types are likely to occur, depending on when the tenant was created/configured:
``
_currentPrincipalId = _currentPrincipal.GetHomeObjectId() ?? _currentPrincipal.GetNameIdentifierId(); // use "sub" claim as a unique identifier in B2C
``